### PR TITLE
Move model data serialization and deserialization to separate methods

### DIFF
--- a/src/Mpociot/Versionable/Version.php
+++ b/src/Mpociot/Versionable/Version.php
@@ -47,13 +47,9 @@ class Version extends Eloquent
      */
     public function getModel()
     {
-        $modelData = is_resource($this->model_data)
-            ? stream_get_contents($this->model_data)
-            : $this->model_data;
-
         $model = new $this->versionable_type();
         $model->unguard();
-        $model->fill(unserialize($modelData));
+        $model->fill($this->modelData());
         $model->exists = true;
         $model->reguard();
         return $model;
@@ -104,4 +100,24 @@ class Version extends Eloquent
         return $diffArray;
     }
 
+    /**
+     * Copy attributes of a model to be saved with the version
+     * 
+     * @param Model $model
+     */
+    public function copyModelData(Model $model)
+    {
+        $this->model_data = serialize($model->getAttributes());
+    }
+
+    /**
+     * Model attributes
+     */
+    protected function modelData()
+    {
+        $serialized = is_resource($this->model_data)
+            ? stream_get_contents($this->model_data)
+            : $this->model_data;
+        return unserialize($serialized);
+    }
 }

--- a/src/Mpociot/Versionable/VersionableTrait.php
+++ b/src/Mpociot/Versionable/VersionableTrait.php
@@ -175,7 +175,7 @@ trait VersionableTrait
             $version->versionable_id   = $this->getKey();
             $version->versionable_type = get_class($this);
             $version->user_id          = $this->getAuthUserId();
-            $version->model_data       = serialize($this->getAttributes());
+            $version->copyModelData($this);
 
             if (!empty( $this->reason )) {
                 $version->reason = $this->reason;


### PR DESCRIPTION
This allows extending the Version class and changing the migration
to store model data differently

Implements #44